### PR TITLE
Support shorthand for named views' components

### DIFF
--- a/src/uiRouterConfig.ts
+++ b/src/uiRouterConfig.ts
@@ -1,7 +1,9 @@
 /** @module ng2 */ /** */
 import { UIRouter, isFunction, StateObject } from "ui-router-core";
 import {StatesModule, RootModule} from "./uiRouterNgModule";
-import {Injector} from "@angular/core";
+import { Ng2StateDeclaration, Ng2ViewDeclaration } from "./interface";
+import { Injector, Type } from "@angular/core";
+import { DirectiveResolver } from '@angular/compiler';
 import {isDefined} from "ui-router-core";
 
 export function applyModuleConfig(uiRouter: UIRouter, injector: Injector, module: StatesModule = {}): StateObject[] {
@@ -10,6 +12,7 @@ export function applyModuleConfig(uiRouter: UIRouter, injector: Injector, module
   }
 
   let states = module.states || [];
+  validNamedViewsComponents(states);
   return states.map(state => uiRouter.stateRegistry.register(state));
 }
 
@@ -18,4 +21,24 @@ export function applyRootModuleConfig(uiRouter: UIRouter, injector: Injector, mo
   isDefined(module.otherwise)      && uiRouter.urlService.rules.otherwise(module.otherwise);
 }
 
+function validNamedViewsComponents(states: Ng2StateDeclaration[]) {
+  for (let state of states) {
+    for (let key in state.views) {
+      let view: Ng2ViewDeclaration | Type<any> = state.views[key];
+      if (isComponent(view)) {
+        state.views[key] = { component: view };
+      }
+    }
+  }
+}
 
+function isComponent(obj: any): obj is Type<any> {
+  return isType(obj) && directiveResolver.isDirective(obj);
+}
+
+let directiveResolver = new DirectiveResolver();
+
+// TODO: remove and use Ng implementation when upgrade to Ng4.
+function isType(v: any): v is Type<any> {
+  return typeof v === 'function';
+}


### PR DESCRIPTION
We can use named views in ng2
```
views: {
  foo: { component: FooCompoent }
}
```
or the shorthand
```
views: {
  foo: FooCompoent
}
```

Fixes #19.