### PR TITLE
[lazyload] fixed getting parent injector in angular 4.2.

### DIFF
--- a/src/lazyLoad/lazyLoadNgModule.ts
+++ b/src/lazyLoad/lazyLoadNgModule.ts
@@ -133,7 +133,7 @@ export function loadModuleFactory(moduleToLoad: NgModuleToLoad, ng2Injector: Inj
  */
 export function applyNgModule(transition: Transition, ng2Module: NgModuleRef<any>): LazyLoadResult {
   let injector = ng2Module.injector;
-  let parentInjector = <Injector> ng2Module.injector['parent'];
+  let parentInjector = <Injector> ng2Module.injector['parent'] || ng2Module.injector['_parent'];
   let uiRouter: UIRouter = injector.get(UIRouter);
   let registry = uiRouter.stateRegistry;
 


### PR DESCRIPTION
`parent` has been renamed to `_parent` in angular `4.2`