### PR TITLE
fix(package.json): npm shrinkwarp with angular 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/core": "^4.0.0",
-    "@angular/router": "^4.0.0"
+    "@angular/common": "^4.0.0 || ^5.0.0",
+    "@angular/core": "^4.0.0 || ^5.0.0",
+    "@angular/router": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@angular/common": "^4.0.0",


### PR DESCRIPTION
Adapt peerDependencies to make it possible to build npm shrinkwrap.json with angular 5 
( errors with current version )