### PR TITLE
chore(package): update upath to 1.0.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5768,8 +5768,8 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.5.tgz#02cab9ecebe95bbec6d5fc2566325725ab6d1a73"
 
 uri-js@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Yarn complains that `upath` is not compatible with node.js 10. Updating to latest version solves the problem.