### PR TITLE
refactor(lazyload): detect AoT by module

### DIFF
--- a/src/lazyLoad/lazyLoadNgModule.ts
+++ b/src/lazyLoad/lazyLoadNgModule.ts
@@ -115,13 +115,16 @@ export function loadModuleFactory(moduleToLoad: NgModuleToLoad, ng2Injector: Inj
   }
 
   const compiler: Compiler = ng2Injector.get(Compiler);
-  const offlineMode = compiler instanceof Compiler;
 
   const unwrapEsModuleDefault = x => (x && x.__esModule && x['default'] ? x['default'] : x);
-  const compileAsync = (moduleType: Type<any>) => compiler.compileModuleAsync(moduleType);
 
-  const loadChildrenPromise = Promise.resolve(moduleToLoad()).then(unwrapEsModuleDefault);
-  return offlineMode ? loadChildrenPromise : loadChildrenPromise.then(compileAsync);
+  return Promise.resolve(moduleToLoad()).then(unwrapEsModuleDefault)
+    .then((t: NgModuleFactory<any> | Type<any>) => {
+      if (t instanceof NgModuleFactory) {
+        return t;
+      }
+      return compiler.compileModuleAsync(t);
+    });
 }
 
 /**


### PR DESCRIPTION
Previously, the AoT switch `offlineMode` is detected by the presence of `JitCompiler`. However, as the `moduleToLoad` can be passed via public `lazyLoad` interface, there are cases when `moduleToLoad` returns either `NgModuleFactory` or `Type`, thus it is better to invoke `JITCompiler` only when `moduleToLoad` does not return an `NgModuleFactory`.

This change enables the following usage
```ts
export const contactsFutureState = {
  name: 'contacts.**',
  url: '/contacts',
  lazyLoad: loadNgModule(SomeFunctionReturnsTypeOrNgModuleFactory())
}
```

Note that `@angular/router` adopted similar approach, code is [here](https://github.com/angular/angular/blob/8.0.0-beta.6/packages/router/src/router_config_loader.ts#L47).