### PR TITLE
Fix location hash being added twice to URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Report an Issue
 
 Help us make UI-Router better! If you think you might have found a bug, or some other weirdness, start by making sure
@@ -17,10 +16,9 @@ is a bug, it's best to talk it out on
 [StackOverflow](http://stackoverflow.com/questions/ask?tags=angular2,@uirouter/angular) before reporting it. This
 keeps development streamlined, and helps us focus on building great software.
 
-
-Issues only! |
--------------|
-Please keep in mind that the issue tracker is for *issues*. Please do *not* post an issue if you need help or support. Instead, use StackOverflow. |
+| Issues only!                                                                                                                                       |
+| -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Please keep in mind that the issue tracker is for _issues_. Please do _not_ post an issue if you need help or support. Instead, use StackOverflow. |
 
 # Contribute
 
@@ -32,12 +30,10 @@ Please keep in mind that the issue tracker is for *issues*. Please do *not* post
 
 **(4)** Finally, commit some code and open a pull request. Code & commits should abide by the following rules:
 
-- *Always* have test coverage for new features (or regression tests for bug fixes), and *never* break existing tests
+- _Always_ have test coverage for new features (or regression tests for bug fixes), and _never_ break existing tests
 - Commits should represent one logical change each; if a feature goes through multiple iterations, squash your commits down to one
 - Make sure to follow the [Angular commit message format](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format) so your change will appear in the changelog of the next release.
 - Changes should always respect the coding style of the project
-
-
 
 # Developing
 
@@ -47,8 +43,8 @@ Please keep in mind that the issue tracker is for *issues*. Please do *not* post
 
 The code for `ui-router-ng2` is split into two source repositories:
 
-* [UI-Router Core](https://github.com/ui-router/core) (`@uirouter/core` on npm)
-* [UI-Router for Angular 2](https://github.com/ui-router/ng2) (`ui-router-ng2` on npm)
+- [UI-Router Core](https://github.com/ui-router/core) (`@uirouter/core` on npm)
+- [UI-Router for Angular 2](https://github.com/ui-router/ng2) (`ui-router-ng2` on npm)
 
 Clone both repositories into directories next to each other.
 
@@ -89,11 +85,10 @@ instead of the prebuilt version specified in `package.json`.
 
 ## Develop
 
-* `npm run build`: Perform a full build.
-* `npm run watch`: Continuously builds and runs tests when source or tests change.
+- `npm run build`: Perform a full build.
+- `npm run test:watch`: Continuously builds and runs tests when source or tests change.
 
 If you make changes in `@uirouter/core`, run these scripts before rebuilding or re-testing `@uirouter/angular`:
 
-* `npm run build`: Compiles `@uirouter/core` code
-* `npm run watch`: Continuously builds the `@uirouter/core` code when sources change.
-
+- `npm run build`: Compiles `@uirouter/core` code
+- `npm run watch`: Continuously builds the `@uirouter/core` code when sources change.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "release": "release --deps @uirouter/core @uirouter/rx",
     "check-peer-dependencies": "check-peer-dependencies",
     "test": "jest --rootDir test",
+    "test:watch": "jest --rootDir test --watchAll",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --rootDir test --runInBand",
     "test:downstream": "test_downstream_projects",
     "docs": "generate_docs",

--- a/src/location/locationService.ts
+++ b/src/location/locationService.ts
@@ -19,13 +19,21 @@ export class Ng2LocationServices extends BaseLocationServices {
 
   _set(state: any, title: string, url: string, replace: boolean): any {
     const { path, search, hash } = parseUrl(url);
-    const urlPart = search ? path : path + (hash ? '#' + hash : '');
-    const searchPart = search + (hash ? '#' + hash : '');
+
+    const hashWithPrefix = hash ? '#' + hash : '';
+    let urlPath = path;
+    let urlParams = search;
+
+    if (search) {
+      urlParams += hashWithPrefix;
+    } else {
+      urlPath += hashWithPrefix;
+    }
 
     if (replace) {
-      this._locationStrategy.replaceState(state, title, urlPart, searchPart);
+      this._locationStrategy.replaceState(state, title, urlPath, urlParams);
     } else {
-      this._locationStrategy.pushState(state, title, urlPart, searchPart);
+      this._locationStrategy.pushState(state, title, urlPath, urlParams);
     }
   }
 

--- a/test/location/locationService.spec.ts
+++ b/test/location/locationService.spec.ts
@@ -44,6 +44,10 @@ describe('locationService', () => {
       expectUrlReadAfterWrite(HashLocationStrategy, '/foo');
     });
 
+    it('should read/write the url path with single hash', () => {
+      expectUrlReadAfterWrite(HashLocationStrategy, '/foo#test');
+    });
+
     it('should read/write query params', () => {
       expectUrlReadAfterWrite(HashLocationStrategy, '/foo?query1=value1');
     });
@@ -64,6 +68,10 @@ describe('locationService', () => {
   describe('+ HashLocationStrategy', () => {
     it('should read/write the url path', () => {
       expectUrlReadAfterWrite(PathLocationStrategy, '/foo');
+    });
+
+    it('should read/write the url path with single hash', () => {
+      expectUrlReadAfterWrite(PathLocationStrategy, '/foo#test');
     });
 
     it('should read/write query params', () => {


### PR DESCRIPTION
In https://github.com/ui-router/angular/commit/01928775ae28e5beb15f1a5dee62a93ab66e339e, a fix was made for #747, adding hashes before or after search params in the location service. 

This breaks setting URLs with a single hash such as `/home#footer`, which is now being added twice - in the path and the search params like so `home#footer?#footer`

I modified an exemplary add to show this behavior: https://stackblitz.com/edit/angular-uirouter-guglw7

The link is generated in `app.component.html`: https://stackblitz.com/edit/angular-uirouter-guglw7?file=src%2Fapp%2Fapp.component.html

```
<a uiSref="home" [uiParams]="{ '#': 'footer' }" role="button">Home footer</a></li>
```

Click on the "Home footer" link to reproduce this error.

I added a fix to ensure the prefixed hash is only added to one of the parts. To the search path, if it exists, or to the url part if it's empty. I also extended the spec for the case of adding a hash without search.

I also added a `test:watch` command to test and watch tests locally which seemed to be missing (npm run watch does not exist as documented in contributing.md). Some additional format changes were made by the `husky` precommit it seems

