### PR TITLE
refactor: remove unsupported Angular imports

### DIFF
--- a/src/lazyLoad/lazyLoadNgModule.ts
+++ b/src/lazyLoad/lazyLoadNgModule.ts
@@ -1,4 +1,4 @@
-import { NgModuleRef, Injector, NgModuleFactory, Type, Compiler, NgModuleFactoryLoader } from '@angular/core';
+import { NgModuleRef, Injector, NgModuleFactory, Type, Compiler } from '@angular/core';
 import {
   Transition,
   LazyLoadResult,
@@ -84,10 +84,6 @@ export function loadNgModule(
 /**
  * Returns the module factory that can be used to instantiate a module
  *
- * For strings this:
- * - Finds the correct NgModuleFactoryLoader
- * - Loads the new NgModuleFactory from the path string (async)
- *
  * For a Type<any> or Promise<Type<any>> this:
  * - Compiles the component type (if not running with AOT)
  * - Returns the NgModuleFactory resulting from compilation (or direct loading if using AOT) as a Promise
@@ -98,10 +94,6 @@ export function loadModuleFactory(
   moduleToLoad: ModuleTypeCallback,
   ng2Injector: Injector
 ): Promise<NgModuleFactory<any>> {
-  if (isString(moduleToLoad)) {
-    return ng2Injector.get(NgModuleFactoryLoader).load(moduleToLoad);
-  }
-
   const compiler: Compiler = ng2Injector.get(Compiler);
 
   const unwrapEsModuleDefault = (x) => (x && x.__esModule && x['default'] ? x['default'] : x);

--- a/test-angular-versions/v10/src/app/app.module.ts
+++ b/test-angular-versions/v10/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { UIRouterModule } from '@uirouter/angular';
 import { UIRouter } from '@uirouter/core';
 
@@ -19,7 +19,6 @@ export function config(router: UIRouter) {
 
 @NgModule({
   imports: [BrowserModule, UIRouterModule.forRoot({ states, config })],
-  providers: [{ provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader }],
   declarations: [AppComponent, HomeComponent, AboutComponent],
   bootstrap: [AppComponent],
 })

--- a/test-angular-versions/v11/src/app/app.module.ts
+++ b/test-angular-versions/v11/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { UIRouterModule } from '@uirouter/angular';
 import { UIRouter } from '@uirouter/core';
 
@@ -19,7 +19,6 @@ export function config(router: UIRouter) {
 
 @NgModule({
   imports: [BrowserModule, UIRouterModule.forRoot({ states, config })],
-  providers: [{ provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader }],
   declarations: [AppComponent, HomeComponent, AboutComponent],
   bootstrap: [AppComponent],
 })

--- a/test/ngModule/deferInitialRender.spec.ts
+++ b/test/ngModule/deferInitialRender.spec.ts
@@ -6,7 +6,6 @@ import {
   APP_INITIALIZER,
   ApplicationInitStatus,
   Component,
-  NgModuleFactoryLoader,
   SystemJsNgModuleLoader,
 } from '@angular/core';
 import { Ng2StateDeclaration } from '../../src/interface';
@@ -43,7 +42,6 @@ const setupTests = (deferInitialRender: boolean) => {
     declarations: [HomeComponent, AppComponent],
     imports: [routerModule],
     providers: [
-      { provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader },
       { provide: APP_INITIALIZER, useValue: () => appInitializer, multi: true },
     ],
   });

--- a/test/ngModule/deferInitialRender.spec.ts
+++ b/test/ngModule/deferInitialRender.spec.ts
@@ -6,7 +6,6 @@ import {
   APP_INITIALIZER,
   ApplicationInitStatus,
   Component,
-  SystemJsNgModuleLoader,
 } from '@angular/core';
 import { Ng2StateDeclaration } from '../../src/interface';
 

--- a/test/ngModule/lazyModule.spec.ts
+++ b/test/ngModule/lazyModule.spec.ts
@@ -2,7 +2,6 @@ import { async, inject, TestBed } from '@angular/core/testing';
 import { UIRouterModule } from '../../src/uiRouterNgModule';
 import { UIView } from '../../src/directives/uiView';
 import { memoryLocationPlugin, UIRouter } from '@uirouter/core';
-import { NgModuleFactoryLoader, SystemJsNgModuleLoader } from '@angular/core';
 
 declare let System;
 
@@ -40,7 +39,6 @@ describe('lazy loading', () => {
     TestBed.configureTestingModule({
       declarations: [],
       imports: [routerModule],
-      providers: [{ provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader }],
     });
   });
 


### PR DESCRIPTION
Angular v13 removes the deprecated `loadChildren: string` syntax as well
as the supporting `NgModuleFactoryLoader` and `SystemJsNgModuleLoader`.
This commit simply removes those imports and providers. None of the
examples or tests appear to be using the `loadChildren: string` syntax.
In fact, the `Ng2StateDeclaration.loadChildren` does not even have
`string` as a valid type in `ModuleTypeCallback`.

See https://github.com/angular/angular/commit/361273fad5030c900c83d333a779f6edbe20c688

fixes https://github.com/ui-router/angular/issues/949