### PR TITLE
Update uisref on param changing, not only state

### DIFF
--- a/src/directives/uiSref.ts
+++ b/src/directives/uiSref.ts
@@ -115,6 +115,7 @@ export class UISref implements OnChanges {
 
   /** @internal */ private _emit = false;
   /** @internal */ private _statesSub: Subscription;
+  /** @internal */ private _paramsSub: Subscription;
   /** @internal */ private _router: UIRouter;
   /** @internal */ private _anchorUISref: AnchorUISref;
   /** @internal */ private _parent: ParentUIViewInject;
@@ -129,6 +130,7 @@ export class UISref implements OnChanges {
     this._parent = parent;
 
     this._statesSub = _router.globals.states$.subscribe(() => this.update());
+    this._statesSub = _router.globals.params$.subscribe(() => this.update());
   }
 
   /** @internal */
@@ -159,6 +161,7 @@ export class UISref implements OnChanges {
   ngOnDestroy() {
     this._emit = false;
     this._statesSub.unsubscribe();
+    this._paramsSub.unsubscribe();
     this.targetState$.unsubscribe();
   }
 


### PR DESCRIPTION
If you have a link where some of the params are inherited, they will become outdated if the params change without the state changing.

