### PR TITLE
Extending lazy-load functionality to include loading standalone components for specific routes.

### DIFF
--- a/src/directives/uiView.ts
+++ b/src/directives/uiView.ts
@@ -60,7 +60,7 @@ interface InputMapping {
  * @internal
  */
 function ng2ComponentInputs<T>(mirror: ComponentMirror<T>): InputMapping[] {
-  return mirror.inputs.map((input) => ({ prop: input.propName, token: input.templateName }));
+  return mirror.inputs.map((input) => ({ prop: input.templateName, token: input.templateName }));
 };
 
 /**
@@ -339,13 +339,6 @@ export class UIView implements OnInit, OnDestroy {
     const explicitBoundProps = Object.keys(bindings);
     const mirror = reflectComponentType(component);
 
-    // Returns the actual component property for a renamed an input renamed using `@Input('foo') _foo`.
-    // return the `_foo` property
-    const renamedInputProp = (prop: string) => {
-      const input = mirror.inputs.find((i) => i.templateName === prop);
-      return (input && input.propName) || prop;
-    };
-
     // Supply resolve data to component as specified in the state's `bindings: {}`
     const explicitInputTuples = explicitBoundProps.reduce(
       (acc, key) => acc.concat([{ prop: key, token: bindings[key] }]),
@@ -367,7 +360,7 @@ export class UIView implements OnInit, OnDestroy {
       .map(addResolvable)
       .filter((tuple) => tuple.resolvable && tuple.resolvable.resolved)
       .forEach((tuple) => {
-        componentRef.setInput(tuple.resolvable.token, injector.get(tuple.resolvable.token));
+        componentRef.setInput(tuple.prop, injector.get(tuple.resolvable.token));
       });
   }
 }

--- a/src/directives/uiView.ts
+++ b/src/directives/uiView.ts
@@ -1,13 +1,14 @@
 import {
   Component,
-  ComponentFactory,
-  ComponentFactoryResolver,
+  ComponentMirror,
   ComponentRef,
   Inject,
   Injector,
   Input,
   OnDestroy,
   OnInit,
+  reflectComponentType,
+  Type,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
@@ -58,8 +59,8 @@ interface InputMapping {
  *
  * @internal
  */
-const ng2ComponentInputs = (factory: ComponentFactory<any>): InputMapping[] => {
-  return factory.inputs.map((input) => ({ prop: input.propName, token: input.templateName }));
+function ng2ComponentInputs<T>(mirror: ComponentMirror<T>): InputMapping[] {
+  return mirror.inputs.map((input) => ({ prop: input.propName, token: input.templateName }));
 };
 
 /**
@@ -293,12 +294,9 @@ export class UIView implements OnInit, OnDestroy {
     const componentClass = config.viewDecl.component;
 
     // Create the component
-    const compFactoryResolver = componentInjector.get(ComponentFactoryResolver);
-    const compFactory = compFactoryResolver.resolveComponentFactory(componentClass);
-    this._componentRef = this._componentTarget.createComponent(compFactory, undefined, componentInjector);
-
+    this._componentRef = this._componentTarget.createComponent(componentClass, { injector: componentInjector });
     // Wire resolves to @Input()s
-    this._applyInputBindings(compFactory, this._componentRef.instance, context, componentClass);
+    this._applyInputBindings(componentClass, this._componentRef, context);
   }
 
   /**
@@ -327,7 +325,7 @@ export class UIView implements OnInit, OnDestroy {
     const moduleInjector = context.getResolvable(NATIVE_INJECTOR_TOKEN).data;
     const mergedParentInjector = new MergeInjector(moduleInjector, parentComponentInjector);
 
-    return Injector.create(newProviders, mergedParentInjector);
+    return Injector.create({ providers: newProviders, parent: mergedParentInjector });
   }
 
   /**
@@ -336,25 +334,26 @@ export class UIView implements OnInit, OnDestroy {
    * Finds component inputs which match resolves (by name) and sets the input value
    * to the resolve data.
    */
-  private _applyInputBindings(factory: ComponentFactory<any>, component: any, context: ResolveContext, componentClass) {
+  private _applyInputBindings<T>(component: Type<T>, componentRef: ComponentRef<T>, context: ResolveContext): void {
     const bindings = this._uiViewData.config.viewDecl['bindings'] || {};
     const explicitBoundProps = Object.keys(bindings);
+    const mirror = reflectComponentType(component);
 
     // Returns the actual component property for a renamed an input renamed using `@Input('foo') _foo`.
     // return the `_foo` property
     const renamedInputProp = (prop: string) => {
-      const input = factory.inputs.find((i) => i.templateName === prop);
+      const input = mirror.inputs.find((i) => i.templateName === prop);
       return (input && input.propName) || prop;
     };
 
     // Supply resolve data to component as specified in the state's `bindings: {}`
     const explicitInputTuples = explicitBoundProps.reduce(
-      (acc, key) => acc.concat([{ prop: renamedInputProp(key), token: bindings[key] }]),
+      (acc, key) => acc.concat([{ prop: key, token: bindings[key] }]),
       []
     );
 
     // Supply resolve data to matching @Input('prop') or inputs: ['prop']
-    const implicitInputTuples = ng2ComponentInputs(factory).filter((tuple) => !inArray(explicitBoundProps, tuple.prop));
+    const implicitInputTuples = ng2ComponentInputs(mirror).filter((tuple) => !inArray(explicitBoundProps, tuple.prop));
 
     const addResolvable = (tuple: InputMapping) => ({
       prop: tuple.prop,
@@ -368,7 +367,7 @@ export class UIView implements OnInit, OnDestroy {
       .map(addResolvable)
       .filter((tuple) => tuple.resolvable && tuple.resolvable.resolved)
       .forEach((tuple) => {
-        component[tuple.prop] = injector.get(tuple.resolvable.token);
+        componentRef.setInput(tuple.resolvable.token, injector.get(tuple.resolvable.token));
       });
   }
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,6 +1,6 @@
 import { StateDeclaration, _ViewDeclaration, Transition, HookResult } from '@uirouter/core';
 import { Component, Type } from '@angular/core';
-import { ModuleTypeCallback } from './lazyLoad/lazyLoadNgModule';
+import { ComponentTypeCallback, ModuleTypeCallback } from './lazyLoad/lazyLoadNgModule';
 
 /**
  * The StateDeclaration object is used to define a state or nested state.
@@ -25,7 +25,7 @@ import { ModuleTypeCallback } from './lazyLoad/lazyLoadNgModule';
  * }
  * ```
  */
-export interface Ng2StateDeclaration extends StateDeclaration, Ng2ViewDeclaration {
+export interface Ng2StateDeclaration<T = unknown> extends StateDeclaration, Ng2ViewDeclaration<T> {
   /**
    * An optional object used to define multiple named views.
    *
@@ -152,10 +152,28 @@ export interface Ng2StateDeclaration extends StateDeclaration, Ng2ViewDeclaratio
    * }
    * ```
    */
-  loadChildren?: ModuleTypeCallback;
+  loadChildren?: ModuleTypeCallback<T>;
+
+  /**
+   * A function used to lazy load a `Component`.
+   *
+   * When the state is activate the `loadComponent` property should lazy load a standalone `Component`
+   * and use it to render the view of the state
+   *
+   * ### Example:
+   * ```ts
+   * var homeState = {
+   *    name: 'home',
+   *    url: '/home',
+   *    loadComponent: () => import('./home/home.component')
+   *        .then(result => result.HomeComponent)
+   * }
+   * ```
+   */
+  loadComponent?: ComponentTypeCallback<T>;
 }
 
-export interface Ng2ViewDeclaration extends _ViewDeclaration {
+export interface Ng2ViewDeclaration<T = unknown> extends _ViewDeclaration {
   /**
    * The `Component` class to use for this view.
    *
@@ -238,7 +256,7 @@ export interface Ng2ViewDeclaration extends _ViewDeclaration {
    * }
    * ```
    */
-  component?: Type<any>;
+  component?: Type<T>;
 
   /**
    * An object which maps `resolve` keys to [[component]] `bindings`.

--- a/src/statebuilders/lazyLoad.ts
+++ b/src/statebuilders/lazyLoad.ts
@@ -1,6 +1,6 @@
 import { LazyLoadResult, Transition, StateDeclaration } from '@uirouter/core'; // has or is using
 import { BuilderFunction, StateObject } from '@uirouter/core';
-import { loadNgModule } from '../lazyLoad/lazyLoadNgModule';
+import { loadComponent, loadNgModule } from '../lazyLoad/lazyLoadNgModule';
 
 /**
  * This is a [[StateBuilder.builder]] function for ngModule lazy loading in Angular.
@@ -46,6 +46,7 @@ import { loadNgModule } from '../lazyLoad/lazyLoadNgModule';
  *
  */
 export function ng2LazyLoadBuilder(state: StateObject, parent: BuilderFunction) {
+  const loadComponentFn = state['loadComponent'];
   const loadNgModuleFn = state['loadChildren'];
-  return loadNgModuleFn ? loadNgModule(loadNgModuleFn) : state.lazyLoad;
+  return loadComponentFn ? loadComponent(loadComponentFn) : loadNgModuleFn ? loadNgModule(loadNgModuleFn) : state.lazyLoad;
 }

--- a/test-angular-versions/v19-standalone/cypress/e2e/sample_app.cy.js
+++ b/test-angular-versions/v19-standalone/cypress/e2e/sample_app.cy.js
@@ -56,6 +56,7 @@ describe('Angular app', () => {
     cy.get('a').contains('home').should('not.have.class', 'active');
     cy.get('a').contains('lazy.child').should('have.class', 'active');
     cy.get('#default').contains('lazy.child works');
+    cy.get('#lazy-child-provided').contains('provided value');
   });
 
   it('targets named views', () => {

--- a/test-angular-versions/v19-standalone/src/app/lazy/lazy.module.ts
+++ b/test-angular-versions/v19-standalone/src/app/lazy/lazy.module.ts
@@ -1,11 +1,15 @@
-import { NgModule } from '@angular/core';
+import { InjectionToken, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { UIRouterModule } from '@uirouter/angular';
 import { LazyComponent } from './lazy.component';
 
 export const states = [
   { name: 'lazy', url: '/lazy', component: LazyComponent },
-  { name: 'lazy.child', url: '/child', component: LazyComponent },
+  {
+    name: 'lazy.child',
+    url: '/child',
+    loadComponent: () => import("./lazy2.component").then(m => m.Lazy2Component)
+  },
   {
     name: 'lazy.child.viewtarget',
     url: '/viewtarget',
@@ -16,8 +20,16 @@ export const states = [
   },
 ];
 
+export const LAZY_PROVIDER_TOKE = new InjectionToken<string>("lazyProvider");
+
 @NgModule({
   imports: [CommonModule, UIRouterModule.forChild({ states: states })],
+  providers: [
+    {
+      provide: LAZY_PROVIDER_TOKE,
+      useValue: "provided value"
+    }
+  ],
   declarations: [LazyComponent],
 })
 export class LazyModule {}

--- a/test-angular-versions/v19-standalone/src/app/lazy/lazy2.component.ts
+++ b/test-angular-versions/v19-standalone/src/app/lazy/lazy2.component.ts
@@ -8,7 +8,7 @@ import { LAZY_PROVIDER_TOKE } from './lazy.module';
   imports: [UIRouterModule],
   template: `
     <p>{{ state().name }} works!</p>
-    <p>{{ _providedString }}</p>
+    <p id="lazy-child-provided">{{ _providedString }}</p>
     <ui-view></ui-view>
   `,
 })

--- a/test-angular-versions/v19-standalone/src/app/lazy/lazy2.component.ts
+++ b/test-angular-versions/v19-standalone/src/app/lazy/lazy2.component.ts
@@ -1,0 +1,18 @@
+import { Component, inject, input } from '@angular/core';
+import { Ng2StateDeclaration, UIRouterModule } from '@uirouter/angular';
+import { LAZY_PROVIDER_TOKE } from './lazy.module';
+
+@Component({
+  selector: 'app-lazy',
+  standalone: true,
+  imports: [UIRouterModule],
+  template: `
+    <p>{{ state().name }} works!</p>
+    <p>{{ _providedString }}</p>
+    <ui-view></ui-view>
+  `,
+})
+export class Lazy2Component {
+  state = input.required<Ng2StateDeclaration>({ alias: '$state$' });
+  _providedString = inject<string>(LAZY_PROVIDER_TOKE);
+}

--- a/test/loadComponent/bar/bar.component.ts
+++ b/test/loadComponent/bar/bar.component.ts
@@ -2,6 +2,7 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "bar",
-  template: "BAR"
+  template: "BAR",
+  standalone: false
 })
 export class BarComponent {}

--- a/test/loadComponent/bar/bar.component.ts
+++ b/test/loadComponent/bar/bar.component.ts
@@ -1,0 +1,7 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "bar",
+  template: "BAR"
+})
+export class BarComponent {}

--- a/test/loadComponent/foo/foo.component.ts
+++ b/test/loadComponent/foo/foo.component.ts
@@ -1,0 +1,8 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "foo",
+  template: "FOO",
+  standalone: true
+})
+export class FooComponent {}

--- a/test/loadComponent/loadComponent.spec.ts
+++ b/test/loadComponent/loadComponent.spec.ts
@@ -1,0 +1,66 @@
+import { memoryLocationPlugin, UIRouter } from "@uirouter/core";
+import { UIRouterModule } from "../../src/uiRouterNgModule";
+import { inject, TestBed, waitForAsync } from "@angular/core/testing";
+import { UIView } from "../../src/directives/uiView";
+import { Ng2StateDeclaration } from "../../src/interface";
+
+const fooState = {
+  name: 'foo',
+  url: '/foo',
+  loadComponent: () => import("./foo/foo.component").then(result => result.FooComponent)
+};
+
+const barState = {
+  name: 'bar',
+  url: '/bar',
+  loadComponent: () => import("./bar/bar.component").then(result => result.BarComponent)
+};
+
+function configFn(router: UIRouter) {
+  router.plugin(memoryLocationPlugin);
+}
+
+describe('lazy loading', () => {
+
+  beforeEach(() => {
+    const routerModule = UIRouterModule.forRoot({ useHash: true, states: [], config: configFn });
+    TestBed.configureTestingModule({
+      declarations: [],
+      imports: [routerModule]
+    });
+  });
+
+  it('should lazy load a standalone component', waitForAsync(
+    inject([UIRouter], ({ stateRegistry, stateService, globals }: UIRouter) => {
+      stateRegistry.register(fooState);
+      const fixture = TestBed.createComponent(UIView);
+      fixture.detectChanges();
+      const names = stateRegistry.get().map(state => state.name).sort();
+      expect(names.length).toBe(2);
+      expect(names).toEqual(['', 'foo']);
+
+      stateService.go('foo')
+        .then(() => {
+          expect(globals.current.name).toBe('foo');
+          expect((globals.current as Ng2StateDeclaration).component).toBeTruthy();
+          const innerText = fixture.debugElement.nativeElement.textContent.replace(/\s+/g, ' ').trim();
+          expect(innerText).toBe('FOO');
+        });
+    })
+  ));
+
+  it('should throw error if component is not standalone', waitForAsync(
+    inject([UIRouter], ({ stateRegistry, stateService }: UIRouter) => {
+      stateRegistry.register(barState);
+      const fixture = TestBed.createComponent(UIView);
+      fixture.detectChanges();
+      const names = stateRegistry.get().map(state => state.name).sort();
+      expect(names.length).toBe(2);
+      expect(names).toEqual(['', 'bar']);
+
+      const success = () => { throw Error('success not expected') };
+      const error = err => expect(err.detail.message).toBe("Is not a standalone component.");
+      stateService.go('bar').then(success, error);
+    })
+  ));
+});

--- a/test/uiView/resolveBinding.spec.ts
+++ b/test/uiView/resolveBinding.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, Input } from '@angular/core';
+import { Component, Inject, input, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Ng2StateDeclaration, UIRouterModule, UIView } from '../../src';
 import { By } from '@angular/platform-browser';
@@ -18,6 +18,14 @@ describe('uiView', () => {
       @Input('resolve3') _resolve3;
       @Input('resolve4') _resolve4;
       @Input() resolve5;
+      @Input({ alias: 'resolve6' }) _resolve6;
+      @Input({ alias: 'resolve7' }) _resolve7;
+      @Input({ transform: (value: string) => `${value}1` }) resolve8;
+      resolve9 = input<string>("");
+      resolve10 = input<string>("");
+      _resolve11 = input<string>("", { alias: 'resolve11' });
+      _resolve12 = input<string>("", { alias: 'resolve12' });
+      resolve13 = input<string, string>("", { transform: value => `${value}1` });
     }
 
     let comp: ManyResolvesComponent;
@@ -32,6 +40,9 @@ describe('uiView', () => {
           // component_input: 'resolve name'
           resolve2: 'Resolve2',
           resolve4: 'Resolve4',
+          resolve7: 'Resolve7',
+          resolve10: 'Resolve10',
+          resolve12: 'Resolve12'
         },
         resolve: [
           { token: 'resolve1', resolveFn: () => 'resolve1' },
@@ -39,6 +50,14 @@ describe('uiView', () => {
           { token: 'resolve3', resolveFn: () => 'resolve3' },
           { token: 'Resolve4', resolveFn: () => 'resolve4' },
           new Resolvable('resolve5', () => 'resolve5', [], { async: 'NOWAIT' }),
+          { token: 'resolve6', resolveFn: () => 'resolve6' },
+          { token: 'Resolve7', resolveFn: () => 'resolve7' },
+          { token: 'resolve8', resolveFn: () => 'resolve8' },
+          { token: 'resolve9', resolveFn: () => 'resolve9' },
+          { token: 'Resolve10', resolveFn: () => 'resolve10' },
+          { token: 'resolve11', resolveFn: () => 'resolve11' },
+          { token: 'Resolve12', resolveFn: () => 'resolve12' },
+          { token: 'resolve13', resolveFn: () => 'resolve13' }
         ],
       };
 
@@ -78,6 +97,38 @@ describe('uiView', () => {
     it('should bind NOWAIT resolve as a promise object', () => {
       expect(comp.resolve5).toBeDefined();
       expect(typeof comp.resolve5.then).toBe('function');
+    });
+
+    it('should bind resolve by alias to component input templateName', () => {
+      expect(comp._resolve6).toBe('resolve6');
+    });
+
+    it('should bind resolve by alias to the component input templateName specified in state `bindings`', () => {
+      expect(comp._resolve7).toBe('resolve7');
+    });
+
+    it('should bind resolve to the component input name and transform its value', () => {
+      expect(comp.resolve8).toBe('resolve81');
+    });
+
+    it('should bind resolve by name to component input signal name', () => {
+      expect(comp.resolve9()).toBe('resolve9');
+    });
+
+    it('should bind resolve by name to the component input signal specified by `bindings`', () => {
+      expect(comp.resolve10()).toBe('resolve10');
+    });
+
+    it('should bind resolve by name to component input signal templateName', () => {
+      expect(comp._resolve11()).toBe('resolve11');
+    });
+
+    it('should bind resolve by name to the component input signal templateName specified in state `bindings`', () => {
+      expect(comp._resolve12()).toBe('resolve12');
+    });
+
+    it('should bind resolve to the component input signal name and transform its value', () => {
+      expect(comp.resolve13()).toBe('resolve131');
     });
 
     /////////////////////////////////////////


### PR DESCRIPTION
Hi, This is a work in progress that I will like to present to you. It covers 3 significant changes, most of them related to the lazy-load functionality.

1. Updating `loadNgModule` and the related functionality to stop using `@deprecated` Angular APIs.
2. Creation of a new property, `loadComponent`, and related functionality to lazy-load standalone components.
3. Updating `ui-view` component  to replace `@deprecated` Angular APIs. The APIs changes are significant as this update will make components rendered using ui-view work well with the newer input Signals.

Please let me know any feedback regarding this changes,

Thanks you all.